### PR TITLE
Fix for aws_nodepool and aws_cluster dependency when updating

### DIFF
--- a/docs/resources/aws_nodepool.md
+++ b/docs/resources/aws_nodepool.md
@@ -14,12 +14,13 @@ The TMC Cluster resource allows requesting the creation of a nodepool for a AWS 
 resource "tmc_aws_nodepool" "example" {
   name               = "default-node-pool"
   cluster_name       = "example-cluster"
+  cluster_id         = "abcdefghigklmnop"
   management_cluster = "example-aws-hosted"
   provisioner_name   = "example-aws-provisioner"
   worker_node_count  = 1
-  availability_zone = "us-east-1a"
-  instance_type     = "m5.large"
-  version           = "1.20.8-1-amazon2"
+  availability_zone  = "us-east-1a"
+  instance_type      = "m5.large"
+  version            = "1.20.8-1-amazon2"
 }
 ```
 
@@ -32,6 +33,7 @@ The following arguments are supported:
 * `node_labels` - (Optional) (Forces Replacement) A map of node labels to assign to the resource.
 * `cloud_labels` - (Optional) (Forces Replacement) A map of cloud labels to assign to the resource.
 * `cluster_name` - (Required) (Forces Replacement) The name of the Tanzu Cluster for which the nodepool is to be created.
+* `cluster_id` - (Required) (Forces Replacement) The unique ID of the cluster for which the nodepool is to be created
 * `management_cluster` - (Required) (Forces Replacement) Name of the management cluster used to provision the cluster.
 * `provisioner_name` - (Required) (Forces Replacement) Name of the provisioner to be used.
 * `availability_zone` - (Required) (Forces Replacement) The AWS availability zone for the cluster's worker nodes.

--- a/tmc/resource_tmc_aws_nodepool.go
+++ b/tmc/resource_tmc_aws_nodepool.go
@@ -130,6 +130,7 @@ func resourceAwsNodePoolCreate(ctx context.Context, d *schema.ResourceData, m in
 		Pending: []string{
 			"CREATING",
 			"WAITING",
+			"UPGRADING",
 		},
 		Target: []string{
 			"READY",
@@ -260,6 +261,8 @@ func resourceAwsNodePoolUpdate(ctx context.Context, d *schema.ResourceData, m in
 			Pending: []string{
 				"CREATING",
 				"RESIZING",
+				"WAITING",
+				"UPGRADING",
 			},
 			Target: []string{
 				"READY",

--- a/tmc/resource_tmc_aws_nodepool.go
+++ b/tmc/resource_tmc_aws_nodepool.go
@@ -43,6 +43,12 @@ func resourceAwsNodePool() *schema.Resource {
 				ForceNew:    true,
 				Description: "Name of the cluster in which the nodepool is present",
 			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Unique ID of the cluster in which the nodepool is present",
+			},
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -177,6 +183,18 @@ func resourceAwsNodePoolRead(ctx context.Context, d *schema.ResourceData, m inte
 		})
 		return diags
 	}
+
+	cluster, err := client.GetCluster(cluster_name, managementClusterName, provisionerName)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed to read AWS nodepool",
+			Detail:   fmt.Sprintf("Error reading resource %s: %s", d.Get("name"), err),
+		})
+		return diags
+	}
+
+	d.Set("cluster_id", cluster.Meta.UID)
 
 	nodeCount, _ := strconv.Atoi(nodepool.Spec.WorkerNodeCount)
 


### PR DESCRIPTION
Closes #29 

Added a new attribute `cluster_id` as a required input from the user to force the recreation of nodepool when only the cluster is updated.